### PR TITLE
hotfix/14 : theme 타입 설정 및 경로 별칭 순서 수정

### DIFF
--- a/src/style/emotion.d.ts
+++ b/src/style/emotion.d.ts
@@ -1,8 +1,8 @@
 import '@emotion/react';
 import { theme } from './theme';
 
-type ThemeTpye = typeof theme;
+type ThemeType = typeof theme;
 
 declare module '@emotion/react' {
-  export interface Theme extends ThemeTpye {}
+  export interface Theme extends ThemeType {}
 }

--- a/src/style/emotion.d.ts
+++ b/src/style/emotion.d.ts
@@ -1,5 +1,8 @@
 import '@emotion/react';
+import { theme } from './theme';
+
+type ThemeTpye = typeof theme;
 
 declare module '@emotion/react' {
-  export interface Theme extends Record<string, any> {}
+  export interface Theme extends ThemeTpye {}
 }

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,7 +1,7 @@
 export const theme = {
   // 미디어 쿼리
   mediaQueries: {
-    small: '@media (max-width: 640px)',
+    small: '@media (max-width: 480px)',
     medium: '@media (max-width: 768px)',
     large: '@media (max-width: 1024px)',
   },
@@ -31,12 +31,15 @@ export const theme = {
       dark: '#333333',
     },
   },
-  // 기본 padding, 헤더 높이 등
+  // 기본 padding, 헤더 높이, z-index 등
   space: {
     padding: '16px',
   },
   sizes: {
     headerHeight: '60px',
+  },
+  zIndex: {
+    tooltip: '100',
   },
   // 유틸리티 스타일
   utils: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,9 @@
     /* path alias */
     "baseUrl": "./src",
     "paths": {
-      "@/*": ["./*"],
+      "@common/*": ["components/_common/*"],
       "@ui/*": ["components/_ui/*"],
-      "@common/*": ["components/_common/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## ✏ 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1.  theme.ts를 ThemeProvider로 전달 시 theme 타입을 전역에 알려주어야 하는 문제가 있었습니다.
2. 경로 별칭이 tsconfig.json에서 `@/` 가 먼저 선언되어 있다 보니 나머지 별칭이 자동완성에 추천되지 않는 문제가 있었습니다.

## :writing_hand: PR 유형
<!-- 변경된 사항의 유형을 전부 선택해주세요-->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] storybook 테스트
- [ ] 파일 혹은 폴더명 수정/삭제
- [ ] 기타

## :link: 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 끌어오기 링크를 추가해 주세요. ex) #1 -->
이슈번호 : #14 

## ✅ 리뷰 포인트
<!-- 이 PR에서 리뷰어들에게 알려줘야될 정보나 받아야될 피드백이 있다면 설명해주세요 -->

## :heavy_plus_sign: 추가 정보
<!-- PR에 대한 추가적인 설명이나 코멘트가 있다면 여기에 작성해 주세요. -->
1. 경로 별칭 선언 순서를 변경하여 src에서 가장 먼 경로 별칭부터 추천하도록 하였습니다.
2. emotion.d.ts에 theme의 타입을 가져와 전역 Theme 타입에서 확장하도록 수정하였습니다.
