### PR TITLE
hotfix/41 : 공통 컴포넌트 Profile 내부 navigate 제거

### DIFF
--- a/src/components/_common/Profile/Profile.tsx
+++ b/src/components/_common/Profile/Profile.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { CSSProperties, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { theme } from '@/style/theme';
 
 interface ProfileProps {
@@ -7,7 +8,8 @@ interface ProfileProps {
   fullName: string;
   imageSize?: number;
   fontSize?: number;
-  _id: string;
+  params?: string;
+  _id?: string;
   status?: 'Profile' | 'ProfileImage' | 'ProfileName';
   maxWidth?: number;
   style?: CSSProperties;
@@ -23,16 +25,17 @@ export const Profile = ({
   fullName,
   imageSize = 48,
   fontSize = 18,
-  _id,
+  params = '', // params은 확장성을 위해 추가된 값
+  _id = '',
   status = 'Profile',
   maxWidth = 300,
   ...props
 }: ProfileProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
-
-  // TODO: 링크 추가
+  const navigate = useNavigate();
   const handleUserClick = () => {
-    console.log(_id);
+    if (!_id) return;
+    navigate(`/profile${params}/${_id}`);
   };
 
   return (

--- a/src/components/_common/Profile/Profile.tsx
+++ b/src/components/_common/Profile/Profile.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { CSSProperties, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { theme } from '@/style/theme';
 
 interface ProfileProps {
@@ -30,11 +29,10 @@ export const Profile = ({
   ...props
 }: ProfileProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
-  const navigate = useNavigate();
 
   // TODO: 링크 추가
   const handleUserClick = () => {
-    navigate(`/profile/${_id}`);
+    console.log(_id);
   };
 
   return (


### PR DESCRIPTION
## ✏ 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
공통 컴포넌트 Profile 내부 navigate 제거

## :writing_hand: PR 유형
<!-- 변경된 사항의 유형을 전부 선택해주세요-->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] storybook 테스트
- [ ] 파일 혹은 폴더명 수정/삭제
- [x] 기타

## :link: 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 끌어오기 링크를 추가해 주세요. ex) #1 -->
closes : [#41](https://github.com/prgrms-fe-devcourse/FEDC5_MoMo_inseong/issues/41)
## ✅ 리뷰 포인트
<!-- 이 PR에서 리뷰어들에게 알려줘야될 정보나 받아야될 피드백이 있다면 설명해주세요 -->
공통 컴포넌트 Profile 내부에 있는 navigate를 제거 했습니다.
## :heavy_plus_sign: 추가 정보
<!-- PR에 대한 추가적인 설명이나 코멘트가 있다면 여기에 작성해 주세요. -->
라우팅 기능은 페이지 내부에서 본인이 적재적소에 배치해 주시기 바랍니다.