### PR TITLE
hotfix/45 : 리덕스툴킷 TS 설정 변경

### DIFF
--- a/src/_redux/hooks.ts
+++ b/src/_redux/hooks.ts
@@ -1,0 +1,10 @@
+import {
+  TypedUseSelectorHook,
+  useDispatch as useReduxDispatch,
+  useSelector as useReduxSelector,
+} from 'react-redux';
+import type { AppDispatchType, RootStateType } from './stores';
+
+export const useDispatch: () => AppDispatchType = useReduxDispatch;
+export const useSelector: TypedUseSelectorHook<RootStateType> =
+  useReduxSelector;

--- a/src/_redux/slices/heartsSlice.ts
+++ b/src/_redux/slices/heartsSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 interface IHeartsSlice {
   hearts: string[];
@@ -12,10 +12,8 @@ const heartsSlice = createSlice({
   name: 'heartsSlice',
   initialState,
   reducers: {
-    getHearts: (state, action) => {
-      if (typeof action.payload === 'string') {
-        state.hearts = [...state.hearts, action.payload];
-      }
+    getHearts: (state, action: PayloadAction<string>) => {
+      state.hearts = [...state.hearts, action.payload];
     },
   },
 });

--- a/src/_redux/slices/loginSlice.ts
+++ b/src/_redux/slices/loginSlice.ts
@@ -1,6 +1,7 @@
+import type { RootStateType } from '../stores';
 import { IUser } from '@/api/_types/apiModels';
 import { getApiJWT } from '@/api/apis';
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 interface IUserData {
   isLoading: boolean;
@@ -16,6 +17,12 @@ const initialState: IUserData = {
   userId: '',
 };
 
+/** `<<< thunk 사용 예시 >>>`
+ * @example import { useDispatch } from '@/_redux/hooks'
+ * import { getIsLogin } from '@/_redux/slices/loginSlice'
+ * const dispatch = useDispatch();
+ * dispatch(getIsLogin);
+ */
 export const getIsLogin = createAsyncThunk('authUser', async () => {
   const response = await getApiJWT<IUser>('/auth-user');
   return response.data._id;
@@ -29,13 +36,28 @@ const loginSlice = createSlice({
     builder.addCase(getIsLogin.pending, (state) => {
       state.isLoading = true;
     });
-    builder.addCase(getIsLogin.fulfilled, (state, action) => {
-      state.isLoading = true;
-      state.userId = action.payload;
-    });
+    builder.addCase(
+      getIsLogin.fulfilled,
+      /**
+       * @description action.payload의 타입을 지정해야할 때 PayloadAction 유틸 타입을 사용합니다.
+       * 제네릭으로 action.payload의 타입을 넘겨줍니다.
+       */
+      (state, action: PayloadAction<IUserData['userId']>) => {
+        state.isLoading = true;
+        state.userId = action.payload;
+      },
+    );
     builder.addCase(getIsLogin.rejected, (state) => {
       state.isLoading = false;
     });
   },
 });
+
+/**`<< selector 콜백 예시 >>`
+ * @description useSelector 안에서 (state) => state.reducer 문장을 중복으로 너무 많이 사용해야할 때 선언하면 좋습니다.
+ *
+ * @example const 변수 = useSelector(shouldRedirect);
+ */
+export const shouldRedirect = (state: RootStateType) => state.auth.isLogin;
+
 export default loginSlice.reducer;

--- a/src/_redux/stores.ts
+++ b/src/_redux/stores.ts
@@ -3,7 +3,7 @@ import heartsSlice from './slices/heartsSlice';
 import loginSlice from './slices/loginSlice';
 import { configureStore } from '@reduxjs/toolkit';
 
-export const store = configureStore({
+const stores = configureStore({
   reducer: {
     channels: channelsSlice,
     auth: loginSlice,
@@ -11,7 +11,5 @@ export const store = configureStore({
   },
 });
 
-// Infer the `RootState` and `AppDispatch` types from the store itself
-export type RootStateType = ReturnType<typeof store.getState>;
-// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
-export type AppDispatchType = typeof store.dispatch;
+export type RootStateType = ReturnType<typeof stores.getState>;
+export type AppDispatchType = typeof stores.dispatch;


### PR DESCRIPTION
## ✏ 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 리덕스툴킷에 ts 설정 이슈가 발생했습니다.
2. 로그인 상태값을 가져오는 과정에서 타입을 자동 지정해주지 않는 상황이었습니다.

## :writing_hand: PR 유형
<!-- 변경된 사항의 유형을 전부 선택해주세요-->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] storybook 테스트
- [ ] 파일 혹은 폴더명 수정/삭제
- [ ] 기타

## :link: 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 끌어오기 링크를 추가해 주세요. ex) #1 -->
closes : #45 

## :heavy_plus_sign: Redux-toolkit + TS 사용법
<!-- PR에 대한 추가적인 설명이나 코멘트가 있다면 여기에 작성해 주세요. -->
1. `_redux` 폴더의 `hooks.ts`가 export하는 useSelector와 useDispatch가 기존 리덕스의 것을 대체합니다.
2. useSelector와 useDispatch를 사용할 때는 `@/_redux/hooks` 에서 import해야 정상적인 타입 추론이 가능합니다.
3. action.payload의 타입을 지정해야될 때는 `PayloadAction`에 제네릭으로 원하는 타입을 넘겨줘야합니다. ex) `PayloadAction<string>`
4. thunk를 사용해야되면 dispatch 안에 인자로 thunk를 넣으면 됩니다. ex) `dispatch(getIsLogin)`
5. useSelector 안에 콜백을 매번 똑같은걸 사용해야 한다면 미리 선언된 콜백으로 대체 가능합니다. (코드 참고)

