### PR TITLE
Feature/timeTable-rebuild  투표를 게시글의 수정에서 댓글의 수정으로 변경

### DIFF
--- a/src/_redux/slices/postSlices/getPostSlice.ts
+++ b/src/_redux/slices/postSlices/getPostSlice.ts
@@ -4,7 +4,6 @@ import {
   IMessage,
   IPost,
   IPostTitleCustom,
-  IVote,
 } from '@/api/_types/apiModels';
 import { deleteApiJWT, getApi, postApiJWT, putApiJWT } from '@/api/apis';
 import { createNotification } from '@/api/createNotification';
@@ -117,20 +116,7 @@ export const deleteComment = createAsyncThunk(
 const getPostDetailSlice = createSlice({
   name: 'getPostDetailSlice',
   initialState,
-  reducers: {
-    modifyVoteState: (state, action: PayloadAction<IVote>) => {
-      if (state.post != null) {
-        const modifiedPostTitle: IPostTitleCustom = {
-          ...parseTitle(state.post.title),
-          vote: action.payload,
-        };
-        state.post = {
-          ...state.post,
-          title: JSON.stringify(modifiedPostTitle),
-        };
-      }
-    },
-  },
+  reducers: {},
   extraReducers: (builder) => {
     builder.addCase(createPost.pending, (state) => {
       state.isLoading = true;
@@ -211,7 +197,5 @@ const getPostDetailSlice = createSlice({
     });
   },
 });
-
-export const { modifyVoteState } = getPostDetailSlice.actions;
 
 export const postSlice = getPostDetailSlice.reducer;


### PR DESCRIPTION
## ✏ 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 데이터의 저장을 게시글 제목에서 댓글로 변경하였습니다.
2. 게시글의 수정이 게시글 작성자만 가능하다보니 게시글에서 타인이 수정 가능한 댓글이 가장 적합했습니다.

## :writing_hand: PR 유형
<!-- 변경된 사항의 유형을 전부 선택해주세요-->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] storybook 테스트
- [ ] 파일 혹은 폴더명 수정/삭제
- [ ] 기타

